### PR TITLE
Fix MJ Producer drawing too much power. 

### DIFF
--- a/src/main/java/net/xalcon/energyconverters/common/tiles/TileEntityProducerMj.java
+++ b/src/main/java/net/xalcon/energyconverters/common/tiles/TileEntityProducerMj.java
@@ -48,9 +48,9 @@ public class TileEntityProducerMj extends TileEntityEnergyConvertersProducer imp
 					long requested = receiver.getPowerRequested();
 					if(requested > 0)
 					{
-						long available = (long)Math.min(this.getBridgeEnergyStored() / EnergyConvertersConfig.mjConversion * MjAPI.MJ, requested);
-						long taken = receiver.receivePower(available, false);
-						this.retrieveEnergyFromBridge(available - taken, false);
+						long availableMj = (long) Math.min(this.getBridgeEnergyStored() / EnergyConvertersConfig.mjConversion * MjAPI.MJ,requested);
+						long usedMj = availableMj - receiver.receivePower(availableMj, false);
+						this.retrieveEnergyFromBridge(usedMj / (double) MjAPI.MJ * EnergyConvertersConfig.mjConversion, false);
 					}
 				}
 			}

--- a/src/main/java/net/xalcon/energyconverters/common/tiles/TileEntityProducerMj.java
+++ b/src/main/java/net/xalcon/energyconverters/common/tiles/TileEntityProducerMj.java
@@ -48,7 +48,7 @@ public class TileEntityProducerMj extends TileEntityEnergyConvertersProducer imp
 					long requested = receiver.getPowerRequested();
 					if(requested > 0)
 					{
-						long availableMj = (long) Math.min(this.getBridgeEnergyStored() / EnergyConvertersConfig.mjConversion * MjAPI.MJ,requested);
+						long availableMj = (long) Math.min(this.getBridgeEnergyStored() / EnergyConvertersConfig.mjConversion * MjAPI.MJ, requested);
 						long usedMj = availableMj - receiver.receivePower(availableMj, false);
 						this.retrieveEnergyFromBridge(usedMj / (double) MjAPI.MJ * EnergyConvertersConfig.mjConversion, false);
 					}


### PR DESCRIPTION
This PR fixes #59.

The MJ producer draws too much power from the Energy Bridge because it doesn't convert the used MJ back to internal units.

Here is the current behaviour -  the MJ producer outputs _1MJ/t_ (the MJ Meter limits the rate to 1MJ/t), but the FE consumer draws _1000RF/t_.
![image](https://user-images.githubusercontent.com/2184244/86051267-87078b00-ba2b-11ea-8963-54ca2accb938.png)

Here is the behaviour after applying this patch - the MJ producer outputs _1MJ/t_ and the FE consumer correctly draws _15RF/t_.
![image](https://user-images.githubusercontent.com/2184244/86051711-39d7e900-ba2c-11ea-8fba-3076bf2b33f4.png)
